### PR TITLE
Add random seed command.

### DIFF
--- a/Thor/InteracGenerator/Helper/RIntegrator.cs
+++ b/Thor/InteracGenerator/Helper/RIntegrator.cs
@@ -58,6 +58,12 @@ namespace InteracGenerator
             }
         }
 
+        public static void SetRandomSeed(int seed) 
+        {
+            Engine.Evaluate(string.Format("set.seed({0})", seed));
+            return;
+        }
+
         public static Distribution BootStrapValues(Distribution dist, int size)
         {
 

--- a/Thor/InteracGenerator/Thor.cs
+++ b/Thor/InteracGenerator/Thor.cs
@@ -503,6 +503,12 @@ namespace InteracGenerator
             InteracDynamicHist = new DynamicHist(this) { UseSquareRoot = true };
         }
 
+        public void SetRandomSeed(int seed)
+        {
+            RIntegrator.SetRandomSeed(seed);
+            Accord.Math.Random.Generator.Seed = seed;
+        }
+
         public Distribution[] BestDistribution(Distribution dist, int size, int rounds = 100, int amount = 2)
         {
             if (dist.DistType == Distribution.DistributionType.Feature)

--- a/Thor/ThorCOM/Parser/Commander.cs
+++ b/Thor/ThorCOM/Parser/Commander.cs
@@ -29,6 +29,8 @@ namespace ThorCOM.Parser
         public const string COMMAND_FEATUREMODEL_CALCULATE_VARIANT_FITNESS = "variant_fitness";
         public const string COMMAND_FEATUREMODEL_CALCULATE_VARIANTS = "variant";
 
+        public const string COMMAND_RANDOM_SEED = "random_seed";
+
         public const string COMMAND_NON_FUNCT_PROPERTY_BINARY_SIZE = "binarysize";
         public const string COMMAND_NON_FUNCT_PROPERTY_PERFORMANCE = "performance";
         public const string COMMAND_NON_FUNCT_PROPERTY_MAINMEMORY = "mainmemory";
@@ -271,6 +273,10 @@ namespace ThorCOM.Parser
                             //PATH
                             case COMMAND_OUTPUT_PATH:
                                 output_path = argument[1];
+                                break;
+                            
+                            case COMMAND_RANDOM_SEED:
+                                _model.SetRandomSeed(Convert.ToInt32(argument[1]));
                                 break;
 
                             //FEATURE


### PR DESCRIPTION
The random_seed command is added that sets a random seed in Thor.
Specifically in Accord.Math.Random.Generator as well as in R.
It is only tested for Feature and Interaction Attribute generation but not for the variant generation.